### PR TITLE
signal11 hidapi 0.8.0-rc1 to libusb hidapi 0.9.0

### DIFF
--- a/pkgconfig/hidapi-0.9.0-windows.pc
+++ b/pkgconfig/hidapi-0.9.0-windows.pc
@@ -1,0 +1,11 @@
+prefix=XXX
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: hidapi
+Description: HIDAPI is a multi-platform library which allows an application to interface with USB and Bluetooth HID-Class devices
+Version: hidapi-0.9.0
+Libs: -L${libdir} -lhid -lsetupapi
+Cflags: -I${includedir}/hidapi
+

--- a/scripts/common-libs-functions-source.sh
+++ b/scripts/common-libs-functions-source.sh
@@ -482,14 +482,18 @@ function do_hidapi()
   # Oct 26, 2011, "0.7.0"
 
   # https://github.com/signal11/hidapi/archive/hidapi-0.8.0-rc1.zip
-  # Oct 7, 2013, "0.8.0-rc1", latest
+  # Oct 7, 2013, "0.8.0-rc1", latest on signal11's repository
+
+  # https://github.com/libusb/hidapi/releases
+  # https://github.com/libusb/hidapi/archive/hidapi-0.9.0.zip
+  # Jun 19 2019 "hidapi-0.9.0", maintained releases by libusb
 
   local hidapi_version="$1"
 
   local hidapi_src_folder_name="hidapi-hidapi-${hidapi_version}"
 
   local hidapi_archive="hidapi-${hidapi_version}.zip"
-  local hidapi_url="https://github.com/signal11/hidapi/archive/${hidapi_archive}"
+  local hidapi_url="https://github.com/libusb/hidapi/archive/${hidapi_archive}"
 
   local hidapi_folder_name="${hidapi_src_folder_name}"
 

--- a/scripts/common-versions-source.sh
+++ b/scripts/common-versions-source.sh
@@ -61,7 +61,7 @@ function build_versions()
 
     build_libiconv "1.15"
 
-    do_hidapi "0.8.0-rc1"
+    do_hidapi "0.9.0"
 
     # -------------------------------------------------------------------------
 
@@ -100,7 +100,7 @@ function build_versions()
 
     build_libiconv "1.15"
 
-    do_hidapi "0.8.0-rc1"
+    do_hidapi "0.9.0"
 
     # -------------------------------------------------------------------------
 
@@ -140,7 +140,7 @@ function build_versions()
 
     build_libiconv "1.15"
 
-    do_hidapi "0.8.0-rc1"
+    do_hidapi "0.9.0"
 
     # -------------------------------------------------------------------------
 


### PR DESCRIPTION
- Signal11 repository was not maintained for years, switching to libusb's fork.
- Upgrading to the latest version